### PR TITLE
Fix bug in normalize by fixing closure

### DIFF
--- a/atflow/dataset.py
+++ b/atflow/dataset.py
@@ -227,9 +227,12 @@ class Dataset:
         else:
             control = nest.flatten(control)
 
+        # establish closure
+        inputs_mean = self._inputs_mean
+        inputs_std = self._inputs_std
         def normalize_inputs(data):
-            normalized_data = [((d-mu)/sigma if c else d) for d, mu, sigma, c in zip(data, self._inputs_mean,
-                                                                    self._inputs_std, control)]
+            normalized_data = [((d-mu)/sigma if c else d) for d, mu, sigma, c in zip(data, inputs_mean,
+                                                                    inputs_std, control)]
             return normalized_data
 
         self.normalizer = normalize_inputs


### PR DESCRIPTION
Use appropriate closure to ensure that `normalizer` property function remains correct after statistic update.